### PR TITLE
Feature delete branch from other branch

### DIFF
--- a/gitfeatures/core.py
+++ b/gitfeatures/core.py
@@ -28,13 +28,15 @@ def new_feature(name, prefix):
 
 
 def finish_feature(name, prefix):
-    branch = _current_branch()
-
-    if branch != 'master':
-        _call(["git", "checkout", "master"])
+    cur_branch = _current_branch()
 
     if name:
         branch = prefix + '_' + name
+        if branch == cur_branch:
+            _call(["git", "checkout", "master"])
+    elif cur_branch != 'master':
+        branch = cur_branch
+        _call(["git", "checkout", "master"])
     else:
         sys.exit(__name__ + ": please provide a branch name if on master")
 


### PR DESCRIPTION
Ok, so there were 5 cases identified that needed to be taken care of when issuing `git [feature|hotfix] finish [name]`:

`current branch -> branch to delete`
`a -> b` --- delete b and stay on a
`b -> b`--- checkout master and delete b
`master -> b` --- delete b and stay on master
`a -> <no name>` --- checkout master and delete a
`master -> <no name>` --- error

Edge cases were:
1. If the user provided the same branch name as the one he was currently on
2. If the user didn't provide any name while he was on master
